### PR TITLE
Use time.AfterFunc instead of sleep and go routine

### DIFF
--- a/ratecounter.go
+++ b/ratecounter.go
@@ -12,25 +12,25 @@ type RateCounter struct {
 	interval time.Duration
 }
 
-// Constructs a new RateCounter, for the interval provided
+// NewRateCounter Constructs a new RateCounter, for the interval provided
 func NewRateCounter(intrvl time.Duration) *RateCounter {
 	return &RateCounter{
 		interval: intrvl,
 	}
 }
 
-// Add an event into the RateCounter
+// Incr Add an event into the RateCounter
 func (r *RateCounter) Incr(val int64) {
 	r.counter.Incr(val)
 	go r.scheduleDecrement(val)
 }
 
 func (r *RateCounter) scheduleDecrement(amount int64) {
-	time.Sleep(r.interval)
-	r.counter.Incr(-1 * amount)
+	f := func() { r.counter.Incr(-1 * amount) }
+	time.AfterFunc(r.interval, f)
 }
 
-// Return the current number of events in the last interval
+// Rate Return the current number of events in the last interval
 func (r *RateCounter) Rate() int64 {
 	return r.counter.Value()
 }


### PR DESCRIPTION
First off, thank you for this library! It solved a need I had and I'm running it in a non trivial application.

This PR uses the builtin `time.AfterFun` vs recreating the functionality with sleep and
goroutine.

I'm uncertain it provides material improvement in performance... but it uses a golang builtin.

Feel free to merge or reject as you prefer.