### PR TITLE
Improve memory efficiency, fixes #2

### DIFF
--- a/avgratecounter.go
+++ b/avgratecounter.go
@@ -2,39 +2,46 @@ package ratecounter
 
 import (
 	"strconv"
-	"sync/atomic"
 	"time"
 )
 
 // An AvgRateCounter is a thread-safe counter which returns
 // the ratio between the number of calls 'Incr' and the counter value in the last interval
 type AvgRateCounter struct {
-	hits     int64
-	counter  Counter
+	hits     *RateCounter
+	counter  *RateCounter
 	interval time.Duration
 }
 
 // NewRateCounter Constructs a new AvgRateCounter, for the interval provided
 func NewAvgRateCounter(intrvl time.Duration) *AvgRateCounter {
 	return &AvgRateCounter{
+		hits:     NewRateCounter(intrvl),
+		counter:  NewRateCounter(intrvl),
 		interval: intrvl,
 	}
 }
 
+func (r *AvgRateCounter) WithResolution(resolution int) *AvgRateCounter {
+	if resolution < 1 {
+		panic("AvgRateCounter resolution cannot be less than 1")
+	}
+
+	r.hits = r.hits.WithResolution(resolution)
+	r.counter = r.counter.WithResolution(resolution)
+
+	return r
+}
+
 // Incr Adds an event into the AvgRateCounter
 func (a *AvgRateCounter) Incr(val int64) {
-	atomic.AddInt64(&a.hits, 1)
+	a.hits.Incr(1)
 	a.counter.Incr(val)
-
-	time.AfterFunc(a.interval, func() {
-		atomic.AddInt64(&a.hits, -1)
-		a.counter.Incr(-1 * val)
-	})
 }
 
 // Rate Returns the current ratio between the events count and its values during the last interval
 func (a *AvgRateCounter) Rate() float64 {
-	hits, value := atomic.LoadInt64(&a.hits), a.counter.Value()
+	hits, value := a.hits.Rate(), a.counter.Rate()
 
 	if hits == 0 {
 		return 0 // Avoid division by zero

--- a/avgratecounter.go
+++ b/avgratecounter.go
@@ -50,6 +50,10 @@ func (a *AvgRateCounter) Rate() float64 {
 	return float64(value) / float64(hits)
 }
 
+func (a *AvgRateCounter) Hits() int64 {
+	return a.hits.Rate()
+}
+
 func (a *AvgRateCounter) String() string {
 	return strconv.FormatFloat(a.Rate(), 'e', 5, 64)
 }

--- a/avgratecounter_test.go
+++ b/avgratecounter_test.go
@@ -25,6 +25,54 @@ func TestAvgRateCounter(t *testing.T) {
 	check(0)
 }
 
+func TestAvgRateCounterAdvanced(t *testing.T) {
+	interval := 500 * time.Millisecond
+	almost := 450 * time.Millisecond
+	r := NewAvgRateCounter(interval)
+
+	check := func(expected float64) {
+		val := r.Rate()
+		if val != expected {
+			t.Error("Expected ", val, " to equal ", expected)
+		}
+	}
+
+	check(0)
+	r.Incr(1) // counter = 1, hits = 1
+	check(1.0)
+	time.Sleep(interval - almost)
+	r.Incr(3) // counter = 4, hits = 2
+	check(2.0)
+	time.Sleep(almost)
+	check(3.0) // counter = 3, hits = 1
+	time.Sleep(2 * interval)
+	check(0)
+}
+
+func TestAvgRateCounterNoResolution(t *testing.T) {
+	interval := 500 * time.Millisecond
+	almost := 450 * time.Millisecond
+	r := NewAvgRateCounter(interval).WithResolution(1)
+
+	check := func(expected float64) {
+		val := r.Rate()
+		if val != expected {
+			t.Error("Expected ", val, " to equal ", expected)
+		}
+	}
+
+	check(0)
+	r.Incr(1) // counter = 1, hits = 1
+	check(1.0)
+	time.Sleep(interval - almost)
+	r.Incr(3) // counter = 4, hits = 2
+	check(2.0)
+	time.Sleep(almost)
+	check(0) // counter = 0, hits = 0
+	time.Sleep(2 * interval)
+	check(0)
+}
+
 func TestAvgRateCounter_Incr_ReturnsImmediately(t *testing.T) {
 	interval := 1 * time.Second
 	r := NewRateCounter(interval)

--- a/counter.go
+++ b/counter.go
@@ -10,6 +10,10 @@ func (c *Counter) Incr(val int64) {
 	atomic.AddInt64((*int64)(c), val)
 }
 
+func (c *Counter) Reset() {
+	atomic.StoreInt64((*int64)(c), 0)
+}
+
 // Return the counter's current value
 func (c *Counter) Value() int64 {
 	return atomic.LoadInt64((*int64)(c))

--- a/ratecounter.go
+++ b/ratecounter.go
@@ -2,27 +2,68 @@ package ratecounter
 
 import (
 	"strconv"
+	"sync/atomic"
 	"time"
 )
 
 // A RateCounter is a thread-safe counter which returns the number of times
 // 'Incr' has been called in the last interval
 type RateCounter struct {
-	counter  Counter
-	interval time.Duration
+	counter    Counter
+	interval   time.Duration
+	resolution int
+	partials   []Counter
+	current    int
+	running    int32
 }
 
 // NewRateCounter Constructs a new RateCounter, for the interval provided
 func NewRateCounter(intrvl time.Duration) *RateCounter {
-	return &RateCounter{
+	ratecounter := &RateCounter{
 		interval: intrvl,
+		running:  0,
 	}
+
+	return ratecounter.WithResolution(20)
+}
+
+func (r *RateCounter) WithResolution(resolution int) *RateCounter {
+	if resolution < 1 {
+		panic("RateCounter resolution cannot be less than 1")
+	}
+
+	r.resolution = resolution
+	r.partials = make([]Counter, resolution)
+	r.current = 0
+
+	return r
+}
+
+func (r *RateCounter) run() {
+	if ok := atomic.CompareAndSwapInt32(&r.running, 0, 1); !ok {
+		return
+	}
+
+	go func() {
+		for range time.Tick(time.Duration(float64(r.interval) / float64(r.resolution))) {
+			next := (r.current + 1) % r.resolution
+			r.counter.Incr(-1 * r.partials[next].Value())
+			r.partials[next].Reset()
+			r.current = next
+
+			if r.counter.Value() == 0 {
+				atomic.StoreInt32(&r.running, 0)
+				return
+			}
+		}
+	}()
 }
 
 // Incr Add an event into the RateCounter
 func (r *RateCounter) Incr(val int64) {
 	r.counter.Incr(val)
-	time.AfterFunc(r.interval, func() { r.counter.Incr(-1 * val) })
+	r.partials[r.current].Incr(val)
+	r.run()
 }
 
 // Rate Return the current number of events in the last interval

--- a/ratecounter_test.go
+++ b/ratecounter_test.go
@@ -27,6 +27,31 @@ func TestRateCounter(t *testing.T) {
 	check(0)
 }
 
+func TestRateCounterPartial(t *testing.T) {
+	interval := 500 * time.Millisecond
+	almostinterval := 400 * time.Millisecond
+
+	r := NewRateCounter(interval)
+
+	check := func(expected int64) {
+		val := r.Rate()
+		if val != expected {
+			t.Error("Expected ", val, " to equal ", expected)
+		}
+	}
+
+	check(0)
+	r.Incr(1)
+	check(1)
+	time.Sleep(almostinterval)
+	r.Incr(2)
+	check(3)
+	time.Sleep(almostinterval)
+	check(2)
+	time.Sleep(2 * interval)
+	check(0)
+}
+
 func TestRateCounter_Incr_ReturnsImmediately(t *testing.T) {
 	interval := 1 * time.Second
 	r := NewRateCounter(interval)

--- a/ratecounter_test.go
+++ b/ratecounter_test.go
@@ -27,6 +27,32 @@ func TestRateCounter(t *testing.T) {
 	check(0)
 }
 
+func TestRateCounterResetAndRestart(t *testing.T) {
+	interval := 100 * time.Millisecond
+
+	r := NewRateCounter(interval)
+
+	check := func(expected int64) {
+		val := r.Rate()
+		if val != expected {
+			t.Error("Expected ", val, " to equal ", expected)
+		}
+	}
+
+	check(0)
+	r.Incr(1)
+	check(1)
+	time.Sleep(2 * interval)
+	check(0)
+	time.Sleep(2 * interval)
+	r.Incr(2)
+	check(2)
+	time.Sleep(2 * interval)
+	check(0)
+	r.Incr(2)
+	check(2)
+}
+
 func TestRateCounterPartial(t *testing.T) {
 	interval := 500 * time.Millisecond
 	almostinterval := 400 * time.Millisecond
@@ -49,6 +75,102 @@ func TestRateCounterPartial(t *testing.T) {
 	time.Sleep(almostinterval)
 	check(2)
 	time.Sleep(2 * interval)
+	check(0)
+}
+
+func TestRateCounterHighResolution(t *testing.T) {
+	interval := 500 * time.Millisecond
+	tenth := 50 * time.Millisecond
+
+	r := NewRateCounter(interval).WithResolution(100)
+
+	check := func(expected int64) {
+		val := r.Rate()
+		if val != expected {
+			t.Error("Expected ", val, " to equal ", expected)
+		}
+	}
+
+	check(0)
+	r.Incr(1)
+	check(1)
+	time.Sleep(2 * tenth)
+	r.Incr(1)
+	check(2)
+	time.Sleep(2 * tenth)
+	r.Incr(1)
+	check(3)
+	time.Sleep(interval - 5*tenth)
+	check(3)
+	time.Sleep(2 * tenth)
+	check(2)
+	time.Sleep(2 * tenth)
+	check(1)
+	time.Sleep(2 * tenth)
+	check(0)
+}
+
+func TestRateCounterLowResolution(t *testing.T) {
+	interval := 500 * time.Millisecond
+	tenth := 50 * time.Millisecond
+
+	r := NewRateCounter(interval).WithResolution(4)
+
+	check := func(expected int64) {
+		val := r.Rate()
+		if val != expected {
+			t.Error("Expected ", val, " to equal ", expected)
+		}
+	}
+
+	check(0)
+	r.Incr(1)
+	check(1)
+	time.Sleep(2 * tenth)
+	r.Incr(1)
+	check(2)
+	time.Sleep(2 * tenth)
+	r.Incr(1)
+	check(3)
+	time.Sleep(interval - 5*tenth)
+	check(3)
+	time.Sleep(2 * tenth)
+	check(1)
+	time.Sleep(2 * tenth)
+	check(0)
+	time.Sleep(2 * tenth)
+	check(0)
+}
+
+func TestRateCounterNoResolution(t *testing.T) {
+	interval := 500 * time.Millisecond
+	tenth := 50 * time.Millisecond
+
+	r := NewRateCounter(interval).WithResolution(1)
+
+	check := func(expected int64) {
+		val := r.Rate()
+		if val != expected {
+			t.Error("Expected ", val, " to equal ", expected)
+		}
+	}
+
+	check(0)
+	r.Incr(1)
+	check(1)
+	time.Sleep(2 * tenth)
+	r.Incr(1)
+	check(2)
+	time.Sleep(2 * tenth)
+	r.Incr(1)
+	check(3)
+	time.Sleep(interval - 5*tenth)
+	check(3)
+	time.Sleep(2 * tenth)
+	check(0)
+	time.Sleep(2 * tenth)
+	check(0)
+	time.Sleep(2 * tenth)
 	check(0)
 }
 


### PR DESCRIPTION
It is done by dividing each interval into n buckets and keeping a counter in each bucket. Now each (inteval / n) period we increment index of current bucket, looping at the end. This results in RateCounter incrementing in real-time and decrementing every (interval / n).

This way can keep approximate rate and avg rate in constant memory in contrast to previous approach (each increment spawned a goroutine). We can manipulate resolution of RateCounter with nice default of 20 (interval is divided into 20 parts).

Benchmarks before change:

BenchmarkAvgRateCounter-4                     	 3000000	       646 ns/op	      96 B/op	       2 allocs/op
BenchmarkCounter-4                            	200000000	         8.89 ns/op	       0 B/op	       0 allocs/op
BenchmarkRateCounter-4                        	 2000000	       672 ns/op	      96 B/op	       2 allocs/op
BenchmarkRateCounter_Parallel-4               	 3000000	       476 ns/op	     130 B/op	       2 allocs/op
BenchmarkRateCounter_With5MillionExisting-4   	10000000	       236 ns/op	     136 B/op	       2 allocs/op

Benchmarks after change:
BenchmarkAvgRateCounter-4                     	30000000	        56.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkCounter-4                            	200000000	         8.93 ns/op	       0 B/op	       0 allocs/op
BenchmarkRateCounter-4                        	50000000	        27.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkRateCounter_Parallel-4               	20000000	        70.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkRateCounter_With5MillionExisting-4   	50000000	        27.4 ns/op	       0 B/op	       0 allocs/op

As you can see both speed and memory efficiency improved (reaching almost 0 bytes allocates per operation). The amount of memory required is just just O(resolution).

This should fix #2