### PR TITLE
Add MaxTickRate function

### DIFF
--- a/ratecounter.go
+++ b/ratecounter.go
@@ -76,6 +76,18 @@ func (r *RateCounter) Rate() int64 {
 	return r.counter.Value()
 }
 
+func (r *RateCounter) MaxTickRate() int64 {
+	max := int64(0)
+
+	for _, p := range r.partials {
+		if max < p.Value() {
+			max = p.Value()
+		}
+	}
+
+	return max
+}
+
 func (r *RateCounter) String() string {
 	return strconv.FormatInt(r.counter.Value(), 10)
 }

--- a/ratecounter_test.go
+++ b/ratecounter_test.go
@@ -196,6 +196,38 @@ func TestRateCounter_String(t *testing.T) {
 	}
 }
 
+func TestRateCounterHighResolutionMaxTickRate(t *testing.T) {
+	interval := 500 * time.Millisecond
+	tenth := 50 * time.Millisecond
+
+	r := NewRateCounter(interval).WithResolution(100)
+
+	check := func(expected int64) {
+		val := r.MaxTickRate()
+		if val != expected {
+			t.Error("Expected ", val, " to equal ", expected)
+		}
+	}
+
+	check(0)
+	r.Incr(3)
+	check(3)
+	time.Sleep(2 * tenth)
+	r.Incr(2)
+	check(3)
+	time.Sleep(2 * tenth)
+	r.Incr(4)
+	check(4)
+	time.Sleep(interval - 5*tenth)
+	check(4)
+	time.Sleep(2 * tenth)
+	check(4)
+	time.Sleep(2 * tenth)
+	check(4)
+	time.Sleep(2 * tenth)
+	check(0)
+}
+
 func TestRateCounter_Incr_ReturnsImmediately(t *testing.T) {
 	interval := 1 * time.Second
 	r := NewRateCounter(interval)


### PR DESCRIPTION
This is for counting a maximum instantaneous change in rate. This is useful to calculate number of events in last period without "averaging" effect. i.e. currently if counter is set for 30 seconds duration, and events fire 10 times per second, it'll take 30 seconds for "Rate" to show 300 (or 10 per second). The "MaxTickRate" will show 10 immediately, and it'll stay this way for the next 30 seconds, even if rate drops below it.

It is useful to discover maximum rate for last period of time.