### PR TITLE
Fix flapping test

### DIFF
--- a/avgratecounter_test.go
+++ b/avgratecounter_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestAvgRateCounter(t *testing.T) {
-	interval := 500 * time.Millisecond
+	interval := 50 * time.Millisecond
 	r := NewAvgRateCounter(interval)
 
 	check := func(expectedRate float64, expectedHits int64) {
@@ -29,8 +29,8 @@ func TestAvgRateCounter(t *testing.T) {
 }
 
 func TestAvgRateCounterAdvanced(t *testing.T) {
-	interval := 500 * time.Millisecond
-	almost := 450 * time.Millisecond
+	interval := 50 * time.Millisecond
+	almost := 45 * time.Millisecond
 	r := NewAvgRateCounter(interval)
 
 	check := func(expectedRate float64, expectedHits int64) {
@@ -66,8 +66,8 @@ func TestAvgRateCounterMinResolution(t *testing.T) {
 }
 
 func TestAvgRateCounterNoResolution(t *testing.T) {
-	interval := 500 * time.Millisecond
-	almost := 450 * time.Millisecond
+	interval := 50 * time.Millisecond
+	almost := 45 * time.Millisecond
 	r := NewAvgRateCounter(interval).WithResolution(1)
 
 	check := func(expectedRate float64, expectedHits int64) {

--- a/avgratecounter_test.go
+++ b/avgratecounter_test.go
@@ -31,6 +31,7 @@ func TestAvgRateCounter(t *testing.T) {
 func TestAvgRateCounterAdvanced(t *testing.T) {
 	interval := 50 * time.Millisecond
 	almost := 45 * time.Millisecond
+	gap := 1 * time.Millisecond
 	r := NewAvgRateCounter(interval)
 
 	check := func(expectedRate float64, expectedHits int64) {
@@ -49,7 +50,7 @@ func TestAvgRateCounterAdvanced(t *testing.T) {
 	time.Sleep(interval - almost)
 	r.Incr(3) // counter = 4, hits = 2
 	check(2.0, 2)
-	time.Sleep(almost)
+	time.Sleep(almost + gap)
 	check(3.0, 1) // counter = 3, hits = 1
 	time.Sleep(2 * interval)
 	check(0, 0)
@@ -68,6 +69,7 @@ func TestAvgRateCounterMinResolution(t *testing.T) {
 func TestAvgRateCounterNoResolution(t *testing.T) {
 	interval := 50 * time.Millisecond
 	almost := 45 * time.Millisecond
+	gap := 1 * time.Millisecond
 	r := NewAvgRateCounter(interval).WithResolution(1)
 
 	check := func(expectedRate float64, expectedHits int64) {
@@ -86,7 +88,7 @@ func TestAvgRateCounterNoResolution(t *testing.T) {
 	time.Sleep(interval - almost)
 	r.Incr(3) // counter = 4, hits = 2
 	check(2.0, 2)
-	time.Sleep(almost)
+	time.Sleep(almost + gap)
 	check(0, 0) // counter = 0, hits = 0
 	time.Sleep(2 * interval)
 	check(0, 0)

--- a/ratecounter_test.go
+++ b/ratecounter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRateCounter(t *testing.T) {
-	interval := 500 * time.Millisecond
+	interval := 50 * time.Millisecond
 	r := NewRateCounter(interval)
 
 	check := func(expected int64) {
@@ -28,7 +28,7 @@ func TestRateCounter(t *testing.T) {
 }
 
 func TestRateCounterResetAndRestart(t *testing.T) {
-	interval := 100 * time.Millisecond
+	interval := 50 * time.Millisecond
 
 	r := NewRateCounter(interval)
 
@@ -54,8 +54,8 @@ func TestRateCounterResetAndRestart(t *testing.T) {
 }
 
 func TestRateCounterPartial(t *testing.T) {
-	interval := 500 * time.Millisecond
-	almostinterval := 400 * time.Millisecond
+	interval := 50 * time.Millisecond
+	almost := 40 * time.Millisecond
 
 	r := NewRateCounter(interval)
 
@@ -69,18 +69,18 @@ func TestRateCounterPartial(t *testing.T) {
 	check(0)
 	r.Incr(1)
 	check(1)
-	time.Sleep(almostinterval)
+	time.Sleep(almost)
 	r.Incr(2)
 	check(3)
-	time.Sleep(almostinterval)
+	time.Sleep(almost)
 	check(2)
 	time.Sleep(2 * interval)
 	check(0)
 }
 
 func TestRateCounterHighResolution(t *testing.T) {
-	interval := 500 * time.Millisecond
-	tenth := 50 * time.Millisecond
+	interval := 50 * time.Millisecond
+	tenth := 5 * time.Millisecond
 
 	r := NewRateCounter(interval).WithResolution(100)
 
@@ -111,8 +111,8 @@ func TestRateCounterHighResolution(t *testing.T) {
 }
 
 func TestRateCounterLowResolution(t *testing.T) {
-	interval := 500 * time.Millisecond
-	tenth := 50 * time.Millisecond
+	interval := 50 * time.Millisecond
+	tenth := 5 * time.Millisecond
 
 	r := NewRateCounter(interval).WithResolution(4)
 
@@ -149,12 +149,12 @@ func TestRateCounterMinResolution(t *testing.T) {
 		}
 	}()
 
-	NewRateCounter(500 * time.Millisecond).WithResolution(0)
+	NewRateCounter(50 * time.Millisecond).WithResolution(0)
 }
 
 func TestRateCounterNoResolution(t *testing.T) {
-	interval := 500 * time.Millisecond
-	tenth := 50 * time.Millisecond
+	interval := 50 * time.Millisecond
+	tenth := 5 * time.Millisecond
 
 	r := NewRateCounter(interval).WithResolution(1)
 


### PR DESCRIPTION
Fixes https://github.com/paulbellamy/ratecounter/issues/16

I also reduced time of all tests - they still work fine:
```
# Before
$ go test 
PASS
ok  	_/home/tetafro/dev/ratecounter	9.658s

# After
$ go test 
PASS
ok  	_/home/tetafro/dev/ratecounter	1.218s
```

but now it's easier to run test multiple times:
```
$ go test -count 100
PASS
ok  	_/home/tetafro/dev/ratecounter	121.367s
```