### PR TITLE
Add ResettableRateCounter

### DIFF
--- a/resettable_ratecounter.go
+++ b/resettable_ratecounter.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-// A RateCounter is a thread-safe counter which returns the number of times
-// 'Incr' has been called in the last interval
+// A ResettableRateCounter is a RateCounter wrapper which adds the ability to
+// atomically reset it to 0.
 type ResettableRateCounter struct {
 	ptr atomic.Pointer[RateCounter]
 }

--- a/resettable_ratecounter.go
+++ b/resettable_ratecounter.go
@@ -1,0 +1,74 @@
+package ratecounter
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// A RateCounter is a thread-safe counter which returns the number of times
+// 'Incr' has been called in the last interval
+type ResettableRateCounter struct {
+	ptr atomic.Pointer[RateCounter]
+}
+
+// NewResettableRateCounter Constructs a new ResettableRateCounter, for the interval provided
+func NewResettableRateCounter(interval time.Duration) *ResettableRateCounter {
+	return Resettable(NewRateCounter(interval))
+}
+
+// NewResettableRateCounterWithResolution Constructs a new ResettableRateCounter, for the provided interval and resolution
+func NewResettableRateCounterWithResolution(interval time.Duration, resolution int) *ResettableRateCounter {
+	return Resettable(NewRateCounterWithResolution(interval, resolution))
+}
+
+// Resettable wraps a RateCounter to allow resetting it. Note, this adds a small overhead to each operation.
+func Resettable(rc *RateCounter) *ResettableRateCounter {
+	r := &ResettableRateCounter{}
+	r.ptr.Store(rc)
+	return r
+}
+
+// WithResolution determines the minimum resolution of this counter, default is 20
+func (r *ResettableRateCounter) WithResolution(resolution int) *ResettableRateCounter {
+	r.ptr.Load().WithResolution(resolution)
+	return r
+}
+
+// OnStop allow to specify a function that will be called each time the counter
+// reaches 0. Useful for removing it.
+func (r *ResettableRateCounter) OnStop(f func(*RateCounter)) {
+	r.ptr.Load().OnStop(f)
+}
+
+// Incr Add an event into the RateCounter
+func (r *ResettableRateCounter) Incr(val int64) {
+	r.ptr.Load().Incr(val)
+}
+
+// Rate Return the current number of events in the last interval
+func (r *ResettableRateCounter) Rate() int64 {
+	return r.ptr.Load().Rate()
+}
+
+// MaxRate counts the maximum instantaneous change in rate.
+//
+// This is useful to calculate number of events in last period without
+// "averaging" effect. i.e. currently if counter is set for 30 seconds
+// duration, and events fire 10 times per second, it'll take 30 seconds for
+// "Rate" to show 300 (or 10 per second). The "MaxRate" will show 10
+// immediately, and it'll stay this way for the next 30 seconds, even if rate
+// drops below it.
+func (r *ResettableRateCounter) MaxRate() int64 {
+	return r.ptr.Load().MaxRate()
+}
+
+func (r *ResettableRateCounter) String() string {
+	return r.ptr.Load().String()
+}
+
+// Reset method resets the counter's values to zero, like it was just
+// initialized.
+func (r *ResettableRateCounter) Reset() {
+	old := r.ptr.Load()
+	r.ptr.Store(NewRateCounterWithResolution(old.interval, old.resolution))
+}

--- a/resettable_ratecounter_test.go
+++ b/resettable_ratecounter_test.go
@@ -1,0 +1,69 @@
+package ratecounter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResettableRateCounterResetAndRestart(t *testing.T) {
+	interval := 50 * time.Millisecond
+
+	r := NewResettableRateCounter(interval)
+
+	assert.Equal(t, int64(0), r.Rate())
+	r.Incr(1)
+	assert.Equal(t, int64(1), r.Rate())
+	time.Sleep(2 * interval)
+	assert.Equal(t, int64(0), r.Rate())
+	time.Sleep(2 * interval)
+	r.Incr(2)
+	assert.Equal(t, int64(2), r.Rate())
+	time.Sleep(2 * interval)
+	assert.Equal(t, int64(0), r.Rate())
+	r.Incr(2)
+	assert.Equal(t, int64(2), r.Rate())
+	r.Reset()
+	assert.Equal(t, int64(0), r.Rate())
+	r.Incr(3)
+	assert.Equal(t, int64(3), r.Rate())
+}
+
+func BenchmarkResettableRateCounter(b *testing.B) {
+	interval := 1 * time.Millisecond
+	r := NewResettableRateCounter(interval)
+
+	for i := 0; i < b.N; i++ {
+		r.Incr(1)
+		r.Rate()
+	}
+}
+
+func BenchmarkResettableRateCounter_Parallel(b *testing.B) {
+	interval := 1 * time.Millisecond
+	r := NewResettableRateCounter(interval)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r.Incr(1)
+			r.Rate()
+		}
+	})
+}
+
+func BenchmarkResettableRateCounter_With5MillionExisting(b *testing.B) {
+	interval := 1 * time.Hour
+	r := NewResettableRateCounter(interval)
+
+	for i := 0; i < 5000000; i++ {
+		r.Incr(1)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		r.Incr(1)
+		r.Rate()
+	}
+}


### PR DESCRIPTION
#23

There is a `Counter.Reset()` method, but not a `RateCounter.Reset()` method. Making the `RateCounter` atomically resettable adds some performance overhead, so I've added a new `ResettableRateCounter`, which adds this overhead but has a `Reset()` method.

@cleeland, does this work for you?

Benchmark on my machine for reference:
| Benchmark | Normal | Resettable | Difference |
|-----|--------|-----------|-----------|
| Basic | 330.5 ns/op | 518.3 ns/op | +56.8% |
| Parallel | 467.1 ns/op | 468.3 ns/op | +0.2% |
| With5MillionExisting | 305.5 ns/op | 507.8 ns/op | +66.2% |